### PR TITLE
fix: install.sh 缺少 trae 标签、convert.sh 转义遗漏、workflow 重跑失败

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: Push to Gitee
         run: |
-          git remote add gitee https://jnMetaCode:${{ secrets.GITEE_TOKEN }}@gitee.com/jnMetaCode/agency-agents-zh.git
+          git remote add gitee https://jnMetaCode:${{ secrets.GITEE_TOKEN }}@gitee.com/jnMetaCode/agency-agents-zh.git 2>/dev/null || true
           git push gitee main --force

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -380,7 +380,7 @@ convert_codex() {
   # TOML 多行基本字符串（"""..."""）中反斜杠必须转义为 \\
   # 同时转义三引号（极罕见但防御性处理）
   local escaped_body
-  escaped_body="$(echo "$body" | sed -e 's/\\/\\\\/g' -e 's/"""/\\"""/')"
+  escaped_body="$(echo "$body" | sed -e 's/\\/\\\\/g' -e 's/"""/\\"""/g')"
 
   local escaped_desc
   escaped_desc="$(echo "$description" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,6 +113,7 @@ tool_label() {
     opencode)    printf "%-14s  %s" "OpenCode"     "(opencode.ai)"          ;;
     openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw)"          ;;
     cursor)      printf "%-14s  %s" "Cursor"       "(.cursor/rules)"        ;;
+    trae)        printf "%-14s  %s" "Trae"         "(.trae/rules)"          ;;
     aider)       printf "%-14s  %s" "Aider"        "(CONVENTIONS.md)"       ;;
     windsurf)    printf "%-14s  %s" "Windsurf"     "(.windsurfrules)"       ;;
     qwen)        printf "%-14s  %s" "Qwen Code"    "(~/.qwen/agents)"       ;;


### PR DESCRIPTION
## Summary

在审查项目代码后发现 3 个 bug，修复如下：

### 1. `install.sh` — `tool_label()` 缺少 `trae` 条目
`trae` 在 `ALL_TOOLS`、`detect_trae()`、`install_trae()` 和 `install_tool` case 中均已实现，但 `tool_label()` 函数遗漏了 `trae` 条目。导致运行 `./scripts/install.sh` 全量扫描时，Trae 工具虽然能被检测到，但显示为空行标签。

**修复**: 在 `tool_label()` 的 case 语句中添加 `trae` 条目。

### 2. `convert.sh` — Codex TOML 三引号转义缺少全局替换标志
`convert_codex()` 中 `sed` 替换三引号 `"""` 时缺少 `g` 标志：
```bash
# 修复前（仅替换首个匹配）
sed -e 's/"""/\\"""/'
# 修复后（替换所有匹配）
sed -e 's/"""/\\"""/g'
```
如果智能体正文包含多个 `"""`，后续的三引号不会被转义，生成的 TOML 文件格式损坏。

**修复**: 添加 `g` 标志确保全局替换。

### 3. `sync-to-gitee.yml` — `git remote add` 重跑失败
Workflow 使用 `git remote add gitee ...`，但该命令在远程已存在时（如 workflow 重跑、手动触发）会报错退出导致整个 job 失败。

**修复**: 添加 `2>/dev/null || true` 容错处理。

## Test plan

- [ ] 验证 `./scripts/install.sh` 扫描时 Trae 显示正确标签
- [ ] 验证 `./scripts/convert.sh --tool codex` 生成正确 TOML（含多个 `"""` 的场景）
- [ ] 验证 sync-to-gitee workflow 重跑不再失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)