### PR TITLE
fix: Hermes Discord 模式一次性全量安装触发 8000 字符上限 (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,25 @@ NousResearch 的开源 AI 智能体框架，支持技能系统、子代理编排
 ./scripts/install.sh --tool hermes
 ```
 
-安装后在 Hermes CLI 中可通过 `hermes skills` 查看和管理所有技能，或在对话中自然语言激活。
+安装后**推荐在 Hermes CLI** 中通过 `hermes skills` 查看和管理所有技能，或在对话中自然语言激活。
+
+> ⚠️ **Discord 模式下不要一次性全量安装**
+>
+> Hermes 的 Discord 集成会把每一个 skill 注册成 Discord 斜杠命令，Discord API 对 bot 所有命令的 JSON 序列化总长度有 **8000 字符硬上限**，超过后会返回 `error code 50035`（见 [issue #45](https://github.com/jnMetaCode/agency-agents-zh/issues/45)）。本仓库有近 200 个 skill，一次装全会直接炸 Discord。
+>
+> 解决办法：在 Discord 中使用时请按**分类**分批安装，用 `--category` 参数（可多次传入）：
+>
+> ```bash
+> # 只装 marketing 分类
+> ./scripts/install.sh --tool hermes --category marketing
+>
+> # 同时装 engineering 和 design
+> ./scripts/install.sh --tool hermes --category engineering --category design
+> ```
+>
+> 可选分类：`academic, blender, design, engineering, finance, game-development, godot, hr, legal, marketing, paid-media, product, project-management, roblox-studio, sales, spatial-computing, specialized, supply-chain, support, testing, unity, unreal-engine`。
+>
+> Hermes CLI 本身没有此限制，全量安装可以继续使用。
 </details>
 
 <details>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -24,9 +24,16 @@
 #   hermes       — 复制到 %USERPROFILE%\.hermes\skills\（全局）
 #   kiro         — 复制到 %USERPROFILE%\.kiro\agents\（全局）
 #   all          — 安装所有已检测到的工具（默认）
+#
+# Hermes 专属参数：
+#   -Category <名称[,名称...]>  只安装某一分类下的 skills，可传多个分类。
+#                                Discord 模式下 Hermes 会把每个 skill 注册为斜杠命令，
+#                                总 JSON 超过 8000 字符会被 Discord API 拒绝 (error 50035)，
+#                                若需要在 Discord 中使用建议按分类分批安装。
 
 param(
     [string]$Tool = "all",
+    [string[]]$Category = @(),
     [switch]$Help
 )
 
@@ -336,10 +343,24 @@ function Install-Hermes {
     $src  = Join-Path $Integrations "hermes"
     $dest = Join-Path $Home_ ".hermes\skills"
     if (-not (Test-Path $src)) { Write-Err "integrations\hermes 不存在，请先运行 convert.ps1 -Tool hermes"; return }
+
+    $filterNote = ""
+    if ($Category.Count -gt 0) {
+        foreach ($c in $Category) {
+            if (-not (Test-Path (Join-Path $src $c))) {
+                $avail = (Get-ChildItem -Path $src -Directory | ForEach-Object Name) -join ", "
+                Write-Err "hermes 分类不存在: $c（可选: $avail）"
+                return
+            }
+        }
+        $filterNote = " [分类: $($Category -join ', ')]"
+    }
+
     $count = 0
     # 保留两级目录结构：category/skill-name/SKILL.md
     Get-ChildItem -Path $src -Directory | ForEach-Object {
         $catName = $_.Name
+        if ($Category.Count -gt 0 -and ($Category -notcontains $catName)) { return }
         Get-ChildItem -Path $_.FullName -Directory | ForEach-Object {
             $skillFile = Join-Path $_.FullName "SKILL.md"
             if (Test-Path $skillFile) {
@@ -350,7 +371,11 @@ function Install-Hermes {
             }
         }
     }
-    Write-OK "Hermes Agent: $count 个 skills -> $dest"
+    Write-OK "Hermes Agent: $count 个 skills -> $dest$filterNote"
+    if ($Category.Count -eq 0 -and $count -gt 80) {
+        Write-Warn "Hermes Discord 模式对斜杠命令总长有 8000 字符上限（error 50035）。"
+        Write-Warn "若要在 Discord 中使用，建议用 -Category <名称> 按分类分批安装。"
+    }
 }
 
 function Install-Kiro {
@@ -391,6 +416,11 @@ function Install-Tool {
 
 # --- 入口 ---
 Check-Integrations
+
+if ($Category.Count -gt 0 -and $Tool -ne "hermes") {
+    Write-Warn "-Category 仅对 -Tool hermes 生效，已忽略。"
+    $Category = @()
+}
 
 $selectedTools = @()
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,15 @@
 #   hermes       -- 复制到 ~/.hermes/skills/（全局）
 #   kiro         -- 复制到 ~/.kiro/agents/（全局）
 #   all          -- 安装所有已检测到的工具（默认）
+#
+# Hermes 专属参数：
+#   --category <名称>  只安装某一分类下的 skills，可重复传入多次。
+#                      分类取 integrations/hermes/ 下的目录名，例如：
+#                        --category marketing
+#                        --category engineering --category design
+#                      Discord 模式下 Hermes 会把每个 skill 注册为斜杠命令，
+#                      总 JSON 超过 8000 字符会被 Discord API 拒绝 (error 50035)，
+#                      若需要在 Discord 中使用建议按分类分批安装。
 
 set -euo pipefail
 
@@ -394,12 +403,27 @@ install_hermes() {
 
   [[ -d "$src" ]] || { err "integrations/hermes 不存在。请先运行 convert.sh --tool hermes"; return 1; }
 
+  # 若指定了 --category，只安装命中的分类；否则安装全部
+  local filter_note=""
+  if [[ ${#HERMES_CATEGORIES[@]} -gt 0 ]]; then
+    local c
+    for c in "${HERMES_CATEGORIES[@]}"; do
+      [[ -d "$src/$c" ]] || { err "hermes 分类不存在: ${c}（可选: $(ls "$src" | tr '\n' ' ')）"; return 1; }
+    done
+    filter_note=" [分类: ${HERMES_CATEGORIES[*]}]"
+  fi
+
   mkdir -p "$dest"
 
   # Hermes 保留两级目录结构：category/skill-name/SKILL.md
   local catdir
   while IFS= read -r -d '' catdir; do
     local catname; catname="$(basename "$catdir")"
+    if [[ ${#HERMES_CATEGORIES[@]} -gt 0 ]]; then
+      local matched=false c
+      for c in "${HERMES_CATEGORIES[@]}"; do [[ "$c" == "$catname" ]] && matched=true && break; done
+      $matched || continue
+    fi
     local skilldir
     while IFS= read -r -d '' skilldir; do
       local skillname; skillname="$(basename "$skilldir")"
@@ -410,7 +434,11 @@ install_hermes() {
     done < <(find "$catdir" -mindepth 1 -maxdepth 1 -type d -print0)
   done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
 
-  ok "Hermes Agent: $count 个 skills -> $dest"
+  ok "Hermes Agent: $count 个 skills -> $dest$filter_note"
+  if [[ ${#HERMES_CATEGORIES[@]} -eq 0 && $count -gt 80 ]]; then
+    warn "Hermes Discord 模式对斜杠命令总长有 8000 字符上限（error 50035）。"
+    warn "若要在 Discord 中使用，建议用 --category <名称> 按分类分批安装。"
+  fi
 }
 
 install_kiro() {
@@ -464,15 +492,22 @@ install_tool() {
 # --- 入口 ---
 main() {
   local tool="all"
+  HERMES_CATEGORIES=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --tool)            tool="${2:?'--tool 需要一个值'}"; shift 2 ;;
+      --category)        HERMES_CATEGORIES+=("${2:?'--category 需要一个值'}"); shift 2 ;;
       --no-interactive)  shift ;;
       --help|-h)         usage ;;
       *)                 err "未知选项: $1"; usage ;;
     esac
   done
+
+  if [[ ${#HERMES_CATEGORIES[@]} -gt 0 && "$tool" != "hermes" ]]; then
+    warn "--category 仅对 --tool hermes 生效，已忽略。"
+    HERMES_CATEGORIES=()
+  fi
 
   check_integrations
 


### PR DESCRIPTION
Closes #45

## 问题背景

Hermes 的 Discord 集成会把每个 skill 注册为 Discord 斜杠命令。Discord API 对 bot 所有命令的 JSON 序列化总长度有 **8000 字符硬上限**，超过后返回 `error code 50035`。

本仓库 `integrations/hermes/` 有 191 个 skill，一次性 `./scripts/install.sh --tool hermes` 后在 Discord 模式下必炸。

## 修改内容

### 1. `scripts/install.sh` / `scripts/install.ps1`

新增 `--category`（bash）/ `-Category`（PowerShell）参数，支持按分类分批安装：

```bash
# 只装 marketing
./scripts/install.sh --tool hermes --category marketing

# 同时装多个分类
./scripts/install.sh --tool hermes --category engineering --category design
```

- 分类不存在时报错并列出所有可选分类
- 无 `--category` 且安装数量超过 80 个时，打印 Discord 限制警告
- `--category` 对非 hermes 工具不生效时给出提示

### 2. `README.md`

Hermes 折叠区块新增 Discord 限制说明、分类安装示例、完整可选分类列表，并明确推荐在 Hermes CLI 中使用（CLI 无此限制）。

### 3. Bug fix

修复 `install.sh` 中 CJK 全角括号 `（` 紧跟变量名 `$c` 被 bash 识别成同一标识符，在 `set -u` 下误报 `unbound variable` 的问题。用 `${c}` 显式界定变量名。

## Test plan

- [x] `./scripts/install.sh --tool hermes --category marketing` → 安装 34 个 skill
- [x] `./scripts/install.sh --tool hermes --category engineering --category design` → 安装 38 个 skill（两个分类目录）
- [x] `./scripts/install.sh --tool hermes --category nosuch` → 报错并列出所有合法分类
- [x] `./scripts/install.sh --tool hermes`（全量）→ 191 个 skill + Discord 警告输出
- [x] `bash -n scripts/install.sh` 语法检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)