### PR TITLE
fix(kiro): 修复 Kiro 智能体格式为 .md + YAML frontmatter

### DIFF
--- a/scripts/convert.ps1
+++ b/scripts/convert.ps1
@@ -20,7 +20,7 @@
 #   deerflow     — DeerFlow 2.0 custom skill 文件
 #   workbuddy    — WorkBuddy skill 文件
 #   hermes       — Hermes Agent skill 文件
-#   kiro         — Kiro agent JSON 文件
+#   kiro         — Kiro agent .md 文件（带 YAML frontmatter）
 #   all          — 所有工具（默认）
 
 param(
@@ -341,17 +341,18 @@ function Convert-Kiro {
     $description = Get-Field "description" $Lines
     $slug        = Get-Slug $File
     $body        = Get-Body $Lines
-    $promptsDir  = Join-Path $OutDir "kiro\prompts"
-    New-Item -ItemType Directory -Force -Path $promptsDir | Out-Null
-    $body | Set-Content -Path (Join-Path $promptsDir "${slug}.md") -Encoding UTF8
-    $escapedDesc = $description -replace '"','\"'
+    $kiroDir     = Join-Path $OutDir "kiro"
+    New-Item -ItemType Directory -Force -Path $kiroDir | Out-Null
+    # Kiro 自定义智能体格式：带 YAML frontmatter 的 .md 文件
+    # 放置于 ~/.kiro/agents/<slug>.md
+    # 参考：https://kiro.dev/docs/chat/subagents/
     @"
-{
-  "name": "$slug",
-  "description": "$escapedDesc",
-  "prompt": "file://./prompts/${slug}.md"
-}
-"@ | Set-Content -Path (Join-Path $OutDir "kiro\${slug}.json") -Encoding UTF8
+---
+name: $slug
+description: $description
+---
+$body
+"@ | Set-Content -Path (Join-Path $kiroDir "${slug}.md") -Encoding UTF8
 }
 
 # --- Aider / Windsurf 累积 ---

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -22,7 +22,7 @@
 #   deerflow     — DeerFlow 2.0 custom skill 文件 (skills/custom/<slug>/SKILL.md)
 #   workbuddy    — WorkBuddy skill 文件 (~/.workbuddy/skills/<slug>/SKILL.md)
 #   hermes       — Hermes Agent skill 文件 (~/.hermes/skills/<category>/<slug>/SKILL.md)
-#   kiro         — Kiro agent JSON 文件 (.kiro/agents/*.json + prompts/*.md)
+#   kiro         — Kiro agent .md 文件 (.kiro/agents/*.md，带 YAML frontmatter)
 #   qoder        — Qoder 自定义智能体文件 (.qoder/agents/*.md)
 #   all          — 所有工具（默认）
 #
@@ -533,24 +533,17 @@ convert_kiro() {
   slug="$(slugify_from_file "$file")"
   body="$(get_body "$file")"
 
-  mkdir -p "$OUT_DIR/kiro/prompts"
+  mkdir -p "$OUT_DIR/kiro"
 
-  # 写入 prompt 文件
-  cat > "$OUT_DIR/kiro/prompts/${slug}.md" <<HEREDOC
+  # Kiro 自定义智能体格式：带 YAML frontmatter 的 .md 文件
+  # 放置于 ~/.kiro/agents/<slug>.md
+  # 参考：https://kiro.dev/docs/chat/subagents/
+  cat > "$OUT_DIR/kiro/${slug}.md" <<HEREDOC
+---
+name: ${slug}
+description: ${description}
+---
 ${body}
-HEREDOC
-
-  # 写入 JSON 配置文件
-  # 需要转义 description 中的双引号
-  local escaped_desc
-  escaped_desc="$(echo "$description" | sed 's/"/\\"/g')"
-
-  cat > "$OUT_DIR/kiro/${slug}.json" <<HEREDOC
-{
-  "name": "${slug}",
-  "description": "${escaped_desc}",
-  "prompt": "file://./prompts/${slug}.md"
-}
 HEREDOC
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -382,14 +382,13 @@ function Install-Kiro {
     $src  = Join-Path $Integrations "kiro"
     $dest = Join-Path $Home_ ".kiro\agents"
     if (-not (Test-Path $src)) { Write-Err "integrations\kiro 不存在，请先运行 convert.ps1"; return }
-    New-Item -ItemType Directory -Force -Path (Join-Path $dest "prompts") | Out-Null
-    $count = (Get-ChildItem -Path $src -Filter "*.json" | ForEach-Object { Copy-Item $_.FullName -Destination $dest; 1 } | Measure-Object -Sum).Sum
-    if (Test-Path (Join-Path $src "prompts")) {
-        Get-ChildItem -Path (Join-Path $src "prompts") -Filter "*.md" |
-            ForEach-Object { Copy-Item $_.FullName -Destination (Join-Path $dest "prompts") }
-    }
+    New-Item -ItemType Directory -Force -Path $dest | Out-Null
+    # Kiro 自定义智能体格式：.md 文件（带 YAML frontmatter）
+    # 参考：https://kiro.dev/docs/chat/subagents/
+    $count = (Get-ChildItem -Path $src -Filter "*.md" | ForEach-Object { Copy-Item $_.FullName -Destination $dest; 1 } | Measure-Object -Sum).Sum
     Write-OK "Kiro: $count 个智能体 -> $dest"
-    Write-Warn "提示: 在 Kiro 中使用 '/agent swap' 切换智能体"
+    Write-Warn "提示: Kiro 会自动识别 ~/.kiro/agents/ 下的 .md 文件作为自定义子智能体"
+    Write-Warn "提示: 在对话中使用 '/<agent-name>' 或让 Kiro 自动选择合适的子智能体"
 }
 
 function Install-Tool {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -452,24 +452,19 @@ install_kiro() {
 
   [[ -d "$src" ]] || { err "integrations/kiro 不存在。请先运行 convert.sh --tool kiro"; return 1; }
 
-  mkdir -p "$dest/prompts"
+  mkdir -p "$dest"
 
-  # 复制 JSON 配置文件
+  # Kiro 自定义智能体格式：.md 文件（带 YAML frontmatter）
+  # 参考：https://kiro.dev/docs/chat/subagents/
   local f
   while IFS= read -r -d '' f; do
     cp "$f" "$dest/"
     (( count++ )) || true
-  done < <(find "$src" -maxdepth 1 -name "*.json" -print0)
-
-  # 复制 prompt 文件
-  if [[ -d "$src/prompts" ]]; then
-    while IFS= read -r -d '' f; do
-      cp "$f" "$dest/prompts/"
-    done < <(find "$src/prompts" -maxdepth 1 -name "*.md" -print0)
-  fi
+  done < <(find "$src" -maxdepth 1 -name "*.md" -print0)
 
   ok "Kiro: $count 个智能体 -> $dest"
-  warn "提示: 在 Kiro 中使用 '/agent swap' 切换智能体"
+  warn "提示: Kiro 会自动识别 ~/.kiro/agents/ 下的 .md 文件作为自定义子智能体"
+  warn "提示: 在对话中使用 '/<agent-name>' 或让 Kiro 自动选择合适的子智能体"
 }
 
 install_qoder() {


### PR DESCRIPTION
Kiro 自定义子智能体要求 ~/.kiro/agents/<name>.md 格式（带 YAML
frontmatter），而非之前的 .json + prompts/ 分离结构。

修复内容：
- convert.sh/ps1: convert_kiro 直接生成 .md 文件
- install.sh/ps1: install_kiro 复制 .md 文件而非 .json

参考：https://kiro.dev/docs/chat/subagents/

## What does this PR do?

<!-- Brief description of the change -->

## Agent Information (if adding/modifying an agent)

- **Agent Name**:
- **Category**:
- **Specialty**:

## Checklist

- [ ] Follows the agent template structure from CONTRIBUTING.md
- [ ] Includes YAML frontmatter with `name`, `description`, `color`
- [ ] Has concrete code/template examples (for new agents)
- [ ] Tested in real scenarios
- [ ] Proofread and formatted correctly
