### PR TITLE
fix(install): 修复 install.ps1 在 PowerShell 5.1 的 Join-Path 报错

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -198,7 +198,7 @@ function Install-GeminiCli {
     Copy-Item (Join-Path $src "gemini-extension.json") -Destination $dest
     $count = 0
     Get-ChildItem -Path (Join-Path $src "skills") -Directory | ForEach-Object {
-        $skillDest = Join-Path $dest "skills" $_.Name
+        $skillDest = Join-Path (Join-Path $dest "skills") $_.Name
         New-Item -ItemType Directory -Force -Path $skillDest | Out-Null
         Copy-Item (Join-Path $_.FullName "SKILL.md") -Destination $skillDest
         $count++


### PR DESCRIPTION
## 问题
`scripts/install.ps1` 第 201 行使用了三参数 `Join-Path $dest "skills" $_.Name`。三参数形式依赖 `-AdditionalChildPath`（PowerShell 7+ 才有），在 Windows PowerShell 5.1 下会报错，导致 Gemini CLI 安装失败。

## 修复
改为嵌套 `Join-Path (Join-Path $dest "skills") $_.Name`，同时兼容 5.1 与 7+。

感谢 @lileland 在 #71 中定位并给出修复方案。

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)