### PR TITLE
docs(readme): 优化赞助商版块（位置/版式/文案/招商入口）

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,27 +55,34 @@ ao compose "帮我写一篇关于 AI Agent 的深度分析文章" --run
 
 ---
 
+## 🙏 赞助商
+
+<table>
+<tr>
+<td width="60%">
+  <a href="https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents">
+    <img src="assets/sponsor-compshare.jpeg" alt="优云智算 — 热门国产模型按次调用套餐包，低至 49 元/月起" width="100%">
+  </a>
+</td>
+<td width="40%" valign="top">
+
+**感谢 [优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents) 赞助本项目！**
+
+UCloud 旗下 AI 云平台，国模 **Agent Plan 套餐低至 49 元/月起**，官转稳定海外模型，支持 **Claude Code / Codex / API**，企业级高并发、7×24 技术支持、自助开票。
+
+🎁 **[点此注册领 5 元体验金 →](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)**
+
+</td>
+</tr>
+</table>
+
+---
+
 ## 这是什么？
 
 一套**开箱即用的 AI 角色库**。每个智能体都有明确的身份定义、关键规则、工作流程和交付物，安装到你的 AI 编程工具后用自然语言激活。
 
 **和普通提示词的区别**：普通提示词告诉 AI "你是一个专家"；这里的智能体定义了专家**怎么思考、怎么做事、交付什么**。例如[安全工程师](engineering/engineering-security-engineer.md)会按 OWASP Top 10 逐项审查代码，[小红书运营专家](marketing/marketing-xiaohongshu-operator.md)会输出完整的种草笔记策略和达人合作方案。
-
----
-
-## 🙏 赞助商
-
-<p align="center">
-  <a href="https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents">
-    <img src="assets/sponsor-compshare.jpeg" alt="优云智算 — 热门国产模型按次调用套餐包，低至 49 元/月起" width="100%">
-  </a>
-</p>
-
-感谢 **[优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)** 赞助本项目！
-
-优云智算是 **UCloud 旗下的 AI 云平台**，主打包月、按次的高性价比国模 **Agent Plan 套餐，低至 49 元/月起**；同时提供官转稳定的海外模型，支持接入 **Claude Code、Codex 及 API 调用**，并面向企业提供高并发、7×24 技术支持、自助开票。
-
-> 🎁 **通过本链接注册，即可领取免费 5 元平台体验金** 👉 **[立即注册 →](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@
 </td>
 <td width="40%" valign="top">
 
-**感谢 [优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents) 赞助本项目！**
-
-UCloud 旗下 AI 云平台，国模 **Agent Plan 套餐低至 49 元/月起**，官转稳定海外模型，支持 **Claude Code / Codex / API**，企业级高并发、7×24 技术支持、自助开票。
-
-🎁 **[点此注册领 5 元体验金 →](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)**
+感谢[优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)赞助了本项目！优云智算是UCloud旗下AI云平台，主打包月、按次的高性价比国模Agent Plan套餐,低至49元/月起。同时提供官转稳定海外模型。支持接入 Claude Code、Codex 及 API 调用。支持企业高并发、7*24技术支持、自助开票。通过[此链接](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)注册的用户，可得免费5元平台体验金！
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ---
 
-## 🙏 赞助商
+## 🙏 赞助商 &nbsp;<sub>[想出现在这里？→](mailto:jnMetaCode@qq.com)</sub>
 
 <table>
 <tr>
@@ -35,8 +35,6 @@
 感谢[优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)赞助了本项目！优云智算是UCloud旗下AI云平台，主打包月、按次的高性价比国模Agent Plan套餐,低至49元/月起。同时提供官转稳定海外模型。支持接入 Claude Code、Codex 及 API 调用。支持企业高并发、7*24技术支持、自助开票。
 
 🎁 **通过[此链接](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)注册的用户，可得免费5元平台体验金！**
-
-<sub>📮 想赞助本项目 / 商务合作？联系：[alanalanal@qq.com](mailto:alanalanal@qq.com)</sub>
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 
 <table>
 <tr>
-<td width="60%">
+<td width="55%">
   <a href="https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents">
     <img src="assets/sponsor-compshare.jpeg" alt="优云智算 — 热门国产模型按次调用套餐包，低至 49 元/月起" width="100%">
   </a>
 </td>
-<td width="40%" valign="top">
+<td width="45%" valign="middle">
 
 感谢[优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)赞助了本项目！优云智算是UCloud旗下AI云平台，主打包月、按次的高性价比国模Agent Plan套餐,低至49元/月起。同时提供官转稳定海外模型。支持接入 Claude Code、Codex 及 API 调用。支持企业高并发、7*24技术支持、自助开票。
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,29 @@
 
 ---
 
+## 🙏 赞助商
+
+<table>
+<tr>
+<td width="60%">
+  <a href="https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents">
+    <img src="assets/sponsor-compshare.jpeg" alt="优云智算 — 热门国产模型按次调用套餐包，低至 49 元/月起" width="100%">
+  </a>
+</td>
+<td width="40%" valign="top">
+
+**感谢 [优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents) 赞助本项目！**
+
+UCloud 旗下 AI 云平台，国模 **Agent Plan 套餐低至 49 元/月起**，官转稳定海外模型，支持 **Claude Code / Codex / API**，企业级高并发、7×24 技术支持、自助开票。
+
+🎁 **[点此注册领 5 元体验金 →](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)**
+
+</td>
+</tr>
+</table>
+
+---
+
 ## 🚀 Agency Orchestrator — 让角色库真正跑起来
 
 > **💡 一句话，让多个 AI 专家自动协作，几分钟交付完整方案。**
@@ -52,29 +75,6 @@ ao compose "帮我写一篇关于 AI Agent 的深度分析文章" --run
     <strong>⭐ 查看 Agency Orchestrator — 让 215 个角色为你协作 →</strong>
   </a>
 </p>
-
----
-
-## 🙏 赞助商
-
-<table>
-<tr>
-<td width="60%">
-  <a href="https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents">
-    <img src="assets/sponsor-compshare.jpeg" alt="优云智算 — 热门国产模型按次调用套餐包，低至 49 元/月起" width="100%">
-  </a>
-</td>
-<td width="40%" valign="top">
-
-**感谢 [优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents) 赞助本项目！**
-
-UCloud 旗下 AI 云平台，国模 **Agent Plan 套餐低至 49 元/月起**，官转稳定海外模型，支持 **Claude Code / Codex / API**，企业级高并发、7×24 技术支持、自助开票。
-
-🎁 **[点此注册领 5 元体验金 →](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)**
-
-</td>
-</tr>
-</table>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@
 </td>
 <td width="40%" valign="top">
 
-感谢[优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)赞助了本项目！优云智算是UCloud旗下AI云平台，主打包月、按次的高性价比国模Agent Plan套餐,低至49元/月起。同时提供官转稳定海外模型。支持接入 Claude Code、Codex 及 API 调用。支持企业高并发、7*24技术支持、自助开票。通过[此链接](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)注册的用户，可得免费5元平台体验金！
+感谢[优云智算](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)赞助了本项目！优云智算是UCloud旗下AI云平台，主打包月、按次的高性价比国模Agent Plan套餐,低至49元/月起。同时提供官转稳定海外模型。支持接入 Claude Code、Codex 及 API 调用。支持企业高并发、7*24技术支持、自助开票。
+
+🎁 **通过[此链接](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)注册的用户，可得免费5元平台体验金！**
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 🎁 **通过[此链接](https://passport.compshare.cn/register?referral_code=ETD3L5JBM13CtKARkMORot&ytag=GPU_YY_YX_git_agency-agents)注册的用户，可得免费5元平台体验金！**
 
+<sub>📮 想赞助本项目 / 商务合作？联系：[alanalanal@qq.com](mailto:alanalanal@qq.com)</sub>
+
 </td>
 </tr>
 </table>


### PR DESCRIPTION
在 #75 基础上完善赞助商版块：

- **位置**：移到介绍区之后、Agency Orchestrator 之前（首屏内容最高位，不压第一印象）
- **版式**：左右两栏（图 55% / 文案 45%），文字垂直居中，消除底部留白
- **文案**：采用赞助方提供的完整原文，体验金 CTA 单独成行加粗
- **招商入口**：标题旁加"想出现在这里？→"（mailto:jnMetaCode@qq.com）

🤖 Generated with [Claude Code](https://claude.com/claude-code)