### PR TITLE
docs(readme): 赞助联系处显示邮箱明文

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ---
 
-## 🙏 赞助商 &nbsp;<sub>[想出现在这里？→](mailto:jnMetaCode@qq.com)</sub>
+## 🙏 赞助商 &nbsp;<sub>想出现在这里？联系 [jnMetaCode@qq.com](mailto:jnMetaCode@qq.com)</sub>
 
 <table>
 <tr>


### PR DESCRIPTION
原 `想出现在这里？→` 只是 mailto 链接，依赖默认邮件客户端，很多用户点击无反应、也看不到地址。改为显示邮箱明文 jnMetaCode@qq.com（仍保留 mailto 可点），保证任何人都能复制联系。

🤖 Generated with [Claude Code](https://claude.com/claude-code)