### PR TITLE
fix(install): Hermes skills 安装目录适配 Windows 原生路径 (#82)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -402,7 +402,15 @@ install_workbuddy() {
 
 install_hermes() {
   local src="$INTEGRATIONS/hermes"
-  local dest="${HOME}/.hermes/skills"
+  # 安装目录优先级（issue #82）：官方环境变量 HERMES_HOME > Windows 新版默认位置 > 传统位置
+  local dest
+  if [[ -n "${HERMES_HOME:-}" ]]; then
+    dest="${HERMES_HOME}/skills"
+  elif [[ -n "${LOCALAPPDATA:-}" && -d "${LOCALAPPDATA}/hermes" ]]; then
+    dest="${LOCALAPPDATA}/hermes/skills"
+  else
+    dest="${HOME}/.hermes/skills"
+  fi
   local count=0
 
   [[ -d "$src" ]] || { err "integrations/hermes 不存在。请先运行 convert.sh --tool hermes"; return 1; }


### PR DESCRIPTION
Closes #82

`install_hermes()` 按优先级解析安装目录:
1. `$HERMES_HOME/skills`(官方环境变量)
2. `$LOCALAPPDATA/hermes/skills`(Windows 原生 Hermes Desktop 新版默认,且目录存在时)
3. `~/.hermes/skills`(传统/兜底)

修复 Windows 原生安装把 Hermes 装到 `LOCALAPPDATA` 时,skills 装到 `~/.hermes` 导致读不到的问题。语法 `bash -n` 通过。