### PR TITLE
README:配套课程导流升级(双课+多语言入口)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 |:---:|:---:|:---:|:---:|:---:|
 | **268** | **215** | **53** | **18 种** | **20 个** |
 
-> 📖 **免费配套学习** → [从零学会 AI 编程](https://aiolaola.com/?utm_source=github&utm_campaign=agents)：180 节免费实操课 + 《AI 编程实战三卷书》在线阅读 + 实战社区 · 把这个仓的 268 个角色装进 Claude Code / Cursor / Codex 后配合方法论更高效 · 永久免费
+> 📖 **免费配套学习** → [从零学会 AI 编程](https://aiolaola.com/?utm_source=github&utm_campaign=agents)（180 节）＋ [从零构建 AI 智能体](https://aiolaola.com/course/ai-agent?utm_source=github&utm_campaign=agents)（40 节）：两门免费实操课 + 实战社区，把这个仓的 268 个角色装进 Claude Code / Cursor / Codex 后配合方法论更高效
+>
+> 🌍 Also available in [English](https://aiolaola.com/en?utm_source=github&utm_campaign=agents) · [日本語](https://aiolaola.com/ja?utm_source=github&utm_campaign=agents) · [Español](https://aiolaola.com/es?utm_source=github&utm_campaign=agents) · [한국어](https://aiolaola.com/ko?utm_source=github&utm_campaign=agents) · [繁體中文](https://aiolaola.com/zh-Hant?utm_source=github&utm_campaign=agents)
 
 ---
 


### PR DESCRIPTION
配套学习那行从单课升级为双课(编程 180 节 + 新上线的智能体 40 节),并附上 6 个语言站入口(英/日/西/韩/繁),方便海外 star 用户直达对应语言课程。顺带把「永久免费」收敛为「免费」。