### PR TITLE
修复 Star History Chart 无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,4 +1094,4 @@ MIT License — 自由使用，商业或个人均可。
 
 ## ⭐ Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jnMetaCode/agency-agents-zh&type=Date)](https://star-history.com/#jnMetaCode/agency-agents-zh&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jnMetaCode/agency-agents-zh&type=Date)](https://star-history.dera.page/#jnMetaCode/agency-agents-zh&Date)


### PR DESCRIPTION
README 中的 Star 趋势图表目前由于 GitHub stargazer API 限制而损坏，无法正常加载。本 PR 将图表切换到新的数据源 star-history.dera.page，使 Star 历史图恢复显示。